### PR TITLE
Workaround for bug in dieharder where some output is not printed.

### DIFF
--- a/dieharder-src/dieharder-3.31.1/dieharder/Makefile.am
+++ b/dieharder-src/dieharder-3.31.1/dieharder/Makefile.am
@@ -26,6 +26,7 @@ VERSION=@VERSION@
 # SRCINCLUDES = $(shell ls *.h  2>&1 | sed -e "/\/bin\/ls:/d")
 bin_PROGRAMS = dieharder
 man1_MANS = dieharder.1
+dieharder_CFLAGS= -Wall -fcommon
 dieharder_LDADD = ../libdieharder/libdieharder.la -lgsl -lgslcblas -lm
 dieharder_SOURCES = \
 	add_ui_rngs.c \
@@ -66,7 +67,7 @@ DEFINES = -DVERSION=$(VERSION)
 
 # Compile flags (use fairly standard -O3 as default)
 AM_CPPFLAGS = -I ${top_srcdir}/include $(DEFINES) -I ${includedir}
-AM_CFLAGS = -O3
+AM_CFLAGS = -O3 -fcommon
 
 # Load flags (optional)
 # To build a completely static dieharder, uncomment the following line.

--- a/dieharder-src/dieharder-3.31.1/libdieharder/Makefile.am
+++ b/dieharder-src/dieharder-3.31.1/libdieharder/Makefile.am
@@ -22,7 +22,7 @@ man3_MANS = libdieharder.3
 lib_LTLIBRARIES = libdieharder.la
 libdieharder_la_LIBADD = -lgsl -lgslcblas -lm
 libdieharder_la_LDFLAGS = -version-number @DIEHARDER_LT_VERSION@
-libdieharder_la_CFLAGS = -std=c99 -Wall -pedantic
+libdieharder_la_CFLAGS = -std=c99 -Wall -pedantic -fcommon
 
 # Sources
 # The shell script is the easy way to do this, by far.  But it may not


### PR DESCRIPTION
For some tests, for example STS
  dieharder -d 102 -f 100MB.bin -g 201
only empty lines are printed.

Seen only with gcc-10 and later, this will need to be fixed properly later.

For now, just use -fcommon compiler switch to workaround the problem.